### PR TITLE
fix(adb): immune to adb-version conflicts + live-bound port detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ Player — from one file, fully automatically. Releases are grouped by the BlueS
 
 ---
 
+## v11 — adb robustness: immune to adb-version conflicts + live-bound port detection · 2026-06-02
+
+Fixes a report where a **fully-booted** instance (Home visible, Magisk installed) still failed with
+`instance '<name>' did not boot / become adb-reachable within 300 s`. Root cause was **not** the instance:
+a **system `adb` of a different version** on the host (Android SDK platform-tools **v1.0.41**) and
+BlueStacks' bundled **HD-Adb v1.0.36** were killing each other's adb **server** on the shared default port
+5037 (*"adb server version doesn't match this client; killing…"*), so the tool's `getprop sys.boot_completed`
+calls failed forever and `Boot-And-Wait` timed out.
+
+- 🛡️ **Version-conflict immunity.** The tool now pins BlueStacks' HD-Adb onto its **own private adb server
+  port** (`ANDROID_ADB_SERVER_PORT=15037`) and only ever uses `HD-Adb.exe` (never a system `adb.exe`). A
+  foreign-version adb on 5037 can no longer touch our server. *Proven on this machine:* with a v41 server
+  deliberately running on 5037, HD-Adb `getprop` on 15037 succeeded **30/30**; on the shared 5037 port it
+  failed **0/12** with the exact reporter error; the full `Boot-And-Wait` then booted the instance
+  end-to-end despite the v41 competitor.
+- 🎯 **Port detection hardened.** `Get-AdbPortCandidates` now also consults the **actually-bound listening
+  port** (`Get-NetTCPConnection`, band 5550-5900), merged *after* the `bluestacks.conf`
+  `status.adb_port`/`adb_port` values (which stay authoritative). This rescues the boot wait when the conf
+  is stale — verified live: conf said `status.adb_port=5646` while the instance was really on **5645**, and
+  the live scan found 5645 on **20/20** runs.
+- 🧪 **Tests.** `tests/Run-Resolve-Tests.ps1` gains a deterministic seam + 3 new cases for the conf+live
+  merge/dedup order (25 checks); `Run-Tests.ps1` (28) and `Check-Embedded-Sync.ps1` still pass. Re-embedded
+  into `blueStackRoot.cmd` (engine + orchestrator back in sync).
+- 📄 **No** change to the rooting pipeline, the embedded Magisk APK, or any on-disk format — purely
+  host-side adb plumbing in `tools/bsr_magisk.ps1` (+ a one-line mirror in `tools/bsr_engine.ps1`).
+
+---
+
 ## v10 — Custom Kitsune build: the in-app DenyList now works with ReZygisk · 2026-06-02
 
 Swaps the bundled Magisk for a **custom build of Kitsune Mask v31** (still `31.0-kitsune`, versionCode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,17 @@ BlueStacks' bundled **HD-Adb v1.0.36** were killing each other's adb **server** 
 calls failed forever and `Boot-And-Wait` timed out.
 
 - 🛡️ **Version-conflict immunity.** The tool now pins BlueStacks' HD-Adb onto its **own private adb server
-  port** (`ANDROID_ADB_SERVER_PORT=15037`) and only ever uses `HD-Adb.exe` (never a system `adb.exe`). A
-  foreign-version adb on 5037 can no longer touch our server. *Proven on this machine:* with a v41 server
-  deliberately running on 5037, HD-Adb `getprop` on 15037 succeeded **30/30**; on the shared 5037 port it
-  failed **0/12** with the exact reporter error; the full `Boot-And-Wait` then booted the instance
-  end-to-end despite the v41 competitor.
+  port** and only ever uses `HD-Adb.exe` (never a system `adb.exe`). A foreign-version adb on 5037 can no
+  longer touch our server. *Proven on this machine:* with a v41 server deliberately running on 5037, HD-Adb
+  `getprop` on the private port succeeded **30/30**; on the shared 5037 port it failed **0/12** with the
+  exact reporter error; the full `Boot-And-Wait` then booted the instance end-to-end despite the v41
+  competitor.
+- 🔌 **Free-port selection (no new collisions).** The private port is **chosen free** from `15037–15057`:
+  if something already holds `15037` before the run — a non-adb app *or* a foreign-version adb — the tool
+  steps to the next free port instead of colliding with it (and reuses its own HD-Adb server if one is
+  already up). An explicit `ANDROID_ADB_SERVER_PORT` always wins. *Verified live:* a non-adb listener on
+  15037 → tool picks 15038; its own server on 15037 → reused. The private server is **released when the
+  tool exits** (`kill-server` in a `finally`), so nothing of ours lingers on the port.
 - 🎯 **Port detection hardened.** `Get-AdbPortCandidates` now also consults the **actually-bound listening
   port** (`Get-NetTCPConnection`, band 5550-5900), merged *after* the `bluestacks.conf`
   `status.adb_port`/`adb_port` values (which stay authoritative). This rescues the boot wait when the conf

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   <a href="https://github.com/Jordan231111/BluestacksRoot/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/Jordan231111/BluestacksRoot?style=flat&logo=github"></a>
   <a href="https://github.com/Jordan231111/BluestacksRoot/network/members"><img alt="Forks" src="https://img.shields.io/github/forks/Jordan231111/BluestacksRoot?style=flat&logo=github"></a>
-  <img alt="BlueStacks" src="https://img.shields.io/badge/BlueStacks%205-5.22.169%20%E2%9C%93-blue">
+  <img alt="BlueStacks" src="https://img.shields.io/badge/BlueStacks%205-5.22.210%20%E2%9C%93-blue">
   <img alt="Magisk" src="https://img.shields.io/badge/Magisk-Kitsune%20Mask%20v31-brightgreen">
   <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-CC%20BY--NC--ND%204.0-lightgrey"></a>
 </p>
@@ -11,7 +11,7 @@
 **Root BlueStacks 5 / MSI App Player with real Magisk — from one file, with no traces left behind.**
 **Run `blueStackRoot.cmd` as administrator, pick your Android version, and you're rooted.**
 **A Magisk Delta (Kitsune v31) build is now bundled inside the `.cmd` itself** — no separate Magisk
-download, no other files, nothing to install. Works on the latest BlueStacks (5.22.169).
+download, no other files, nothing to install. Works on the latest BlueStacks (5.22.210).
 
 ---
 
@@ -19,7 +19,7 @@ download, no other files, nothing to install. Works on the latest BlueStacks (5.
 
 Works on the 64-bit BlueStacks instances — **Android 9, 11, and 13**.
 
-**⬇️ [Download `blueStackRoot.cmd`](https://github.com/Jordan231111/BluestacksRoot/releases/download/v9/blueStackRoot.cmd)** — one file (~20 MB) with the **real Magisk APK embedded inside** — nothing else to download. *(All versions: [Releases page](https://github.com/Jordan231111/BluestacksRoot/releases).)*
+**⬇️ [Download `blueStackRoot.cmd`](https://github.com/Jordan231111/BluestacksRoot/releases/download/v11/blueStackRoot.cmd)** — one file (~20 MB) with the **real Magisk APK embedded inside** — nothing else to download. *(All versions: [Releases page](https://github.com/Jordan231111/BluestacksRoot/releases).)*
 
 1. **First, open the exact instance you want to root** — launch it from the Multi-Instance Manager and let
    it boot once. The tool roots the instance of your chosen Android version that you **opened most
@@ -123,7 +123,7 @@ keeps closing** the moment you enable root, that's the **disk-integrity / anti-t
 have to.**
 
 `blueStackRoot` applies a **one-byte HD-Player anti-tamper patch** that bypasses the disk-integrity check,
-so you can **root the *latest* BlueStacks (5.22.169) without downgrading** — and it installs **real Magisk**
+so you can **root the *latest* BlueStacks (5.22.210) without downgrading** — and it installs **real Magisk**
 with **no traces**, not a detectable classic `su`. If `bst.feature.rooting` keeps **reverting to `0`** on
 launch, that's the same anti-tamper system, and this tool handles it for you. Full technical breakdown:
 [`docs/BLUESTACKS_ROOTING_DEEP_DIVE.md`](docs/BLUESTACKS_ROOTING_DEEP_DIVE.md) §2 (the single-byte patch).
@@ -140,7 +140,7 @@ System* button also leaves `/data/adb/magisk` **empty**, so the daemon aborts wi
 incomplete". This tool solves all of that:
 
 1. **One-byte patch** on `HD-Player.exe` (NOP the disk-integrity `JZ`, `74 5B → 90 90`) so a modified
-   `Root.vhd` is accepted and a tampered `/system` boots. It's a version-proof byte-scan; verified on 5.22.169.
+   `Root.vhd` is accepted and a tampered `/system` boots. It's a **version-proof byte-scan**, so it tracks new BlueStacks builds — run on 5.22.169 and the current **5.22.210**.
 2. **Offline write:** using the embedded `debugfs`, it writes Magisk's `/system` payload + a **gated**
    `bootanim.rc` directly into `Root.vhd` — no Windows ext4 driver needed.
 3. **The breakthrough:** it boots once with a tiny **bootstrap su** to populate **`/data/adb/magisk`** (the
@@ -246,4 +246,4 @@ BlueStacks illegally tampered, Android system doesn't meet security requirements
 detected, BlueStacks instance keeps closing after root, BlueStacks disk integrity check bypass, root latest
 BlueStacks without downgrading, fix illegally tampered BlueStacks, bst.feature.rooting reverts to 0,
 "disk file have been illegally tampered with", Verified the disk integrity, BlueStacks disk integrity check,
-root BlueStacks 5.22.169, root BlueStacks latest version 2026.</sub>
+root BlueStacks 5.22.169, root BlueStacks 5.22.210, root BlueStacks latest version 2026.</sub>

--- a/docs/BLUESTACKS_ROOTING_DEEP_DIVE.md
+++ b/docs/BLUESTACKS_ROOTING_DEEP_DIVE.md
@@ -296,6 +296,7 @@ Per‑instance root = presence of `/data/adb/.bsr_root`. **Proven:** `Rvc64` (fl
 | Undo left HD‑Player patched | `-Exe "<path w/ space>" -Restore` glued `-Restore` onto the path | pass `-Exe` **last** |
 | 2nd instance "couldn't launch" | shared master `Root.vhd` was `type="Normal"` (exclusive) | set master **Readonly** (Finalize) |
 | Kitsune Mask leaked to unrooted instances | shared `/system` ⇒ `magiskd` ran everywhere | per‑instance gate (`bsr_boot.sh` + `/data/adb/.bsr_root`) |
+| `did not become adb‑reachable` though the instance booted | a system `adb` (Android SDK **v1.0.41**) and BlueStacks `HD‑Adb` (**v1.0.36**) fight over the default 5037 server (*"server version doesn't match; killing…"*) → `getprop` fails forever | pin HD‑Adb to a **private** `ANDROID_ADB_SERVER_PORT=15037` (proven: 30/30 getprop OK with a v41 server on 5037; 0/12 on the shared port; full `Boot‑And‑Wait` end‑to‑end PASS) + add **live‑bound‑port** discovery (`Get-NetTCPConnection`) so a stale `status.adb_port` can't strand the boot wait |
 
 ---
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -155,6 +155,7 @@ device after completion: **only Magisk's**. No DiskRW, no engine‑su, no daemon
 | Magisk app: *Abnormal State — su not from Magisk* | a stray `/system/xbin/su` (old engine `Root`) | `bsr_engine.ps1 -Action Unroot -Vhd <Root.vhd>` (or re‑run **Clean**) |
 | `su` returns nothing / `uid=2000` after Finalize | shell took BlueStacks' gated su; Magisk daemon down | check `/cache/magisk.log`; ensure `/data/adb/magisk/busybox` exists |
 | Instance won't boot after edits | HD‑Player patch missing | restore `HD-Player.exe.bak`, re‑apply patch, retry |
+| `instance '<x>' did not boot / become adb‑reachable within N s` — **but the instance is up** (Home visible, Magisk installed) | a **system `adb` of a different version** (e.g. Android SDK platform‑tools **v1.0.41**) keeps killing BlueStacks' **HD‑Adb v1.0.36** server on the shared port 5037 — *"adb server version doesn't match this client; killing…"* — so `getprop` calls fail | **fixed in v11**: the tool pins HD‑Adb to its own server port (`ANDROID_ADB_SERVER_PORT=15037`) so the two never collide, and also tries the **live‑bound** adb port, not just `bluestacks.conf`. Update the tool. (Diagnose: compare `adb version` on `PATH` vs `"…\BlueStacks_nxt\HD-Adb.exe" version`.) |
 
 ---
 

--- a/tests/Run-Resolve-Tests.ps1
+++ b/tests/Run-Resolve-Tests.ps1
@@ -99,6 +99,9 @@ Eq 'engine: defaults to 5555 when neither present' '5555' (Resolve-Map (New-Fake
 
 Write-Host "`n=== ADB PORT candidates (orchestrator, dot-sourced) ===" -ForegroundColor Cyan
 . $Magisk   # dispatch guard => nothing boots; functions become available
+# Stub the live-bound-port scan so these conf-only cases are deterministic regardless of what is
+# actually listening on the test host (the seam Get-LiveAdbPorts checks first).
+$script:LiveAdbPortProbe = { @() }
 function Cands([string]$dataDir, [string]$inst) {
     $script:Conf = Join-Path $dataDir 'bluestacks.conf'
     $script:Instance = $inst
@@ -110,6 +113,18 @@ Eq 'cands: adb_port used when status absent'        '5595,5555' ((Cands (New-Fak
 # stale-status case (Rvc64_4 in the wild: status=5555 stale, adb_port=5595 real) -> BOTH tried
 Eq 'cands: stale status + real adb_port both tried' '5555,5595' ((Cands (New-FakeData 'Rvc64_4' @{ 'status.adb_port' = '5555'; 'adb_port' = '5595' } 'c') 'Rvc64_4') -join ',')
 Eq 'cands: no keys -> just the 5555 fallback'       '5555'      ((Cands (New-FakeData 'Foo' @{} 'c') 'Foo') -join ',')
+
+Write-Host "`n=== ADB PORT candidates: live-bound-port merge (rescues a stale conf) ===" -ForegroundColor Cyan
+# conf ports stay FIRST (authoritative when fresh); the live-bound port is appended; 5555 last.
+$script:LiveAdbPortProbe = { @('5646') }
+Eq 'cands: live bound port appended after conf'      '5645,5646,5555' ((Cands (New-FakeData 'Rvc64_9' @{ 'status.adb_port' = '5645' } 'c') 'Rvc64_9') -join ',')
+# the real-world failure mode: conf records NEITHER the bound port -> live scan is the only rescue.
+$script:LiveAdbPortProbe = { @('5646') }
+Eq 'cands: live bound port used when conf has none'  '5646,5555'      ((Cands (New-FakeData 'Bar' @{} 'c') 'Bar') -join ',')
+# a live port that equals a conf port must NOT be duplicated.
+$script:LiveAdbPortProbe = { @('5645', '5646') }
+Eq 'cands: dedup live vs conf (5645 not repeated)'   '5645,5646,5555' ((Cands (New-FakeData 'Rvc64_9' @{ 'status.adb_port' = '5645' } 'c') 'Rvc64_9') -join ',')
+$script:LiveAdbPortProbe = { @() }   # reset so later sections are unaffected
 
 Write-Host "`n=== DataRoot resolution (orchestrator Get-DataRoot, custom/registry) ===" -ForegroundColor Cyan
 Eq 'DataRoot: ...\Engine is normalized to base'      'X:\Custom\BS'   (Get-DataRoot ([pscustomobject]@{ DataDir = 'X:\Custom\BS\Engine'; UserDefinedDir = $null }))

--- a/tests/Run-Resolve-Tests.ps1
+++ b/tests/Run-Resolve-Tests.ps1
@@ -126,6 +126,25 @@ $script:LiveAdbPortProbe = { @('5645', '5646') }
 Eq 'cands: dedup live vs conf (5645 not repeated)'   '5645,5646,5555' ((Cands (New-FakeData 'Rvc64_9' @{ 'status.adb_port' = '5645' } 'c') 'Rvc64_9') -join ',')
 $script:LiveAdbPortProbe = { @() }   # reset so later sections are unaffected
 
+Write-Host "`n=== adb server port: free-port probe (handles a port already in use) ===" -ForegroundColor Cyan
+$savedPort = $env:ANDROID_ADB_SERVER_PORT
+Remove-Item Env:\ANDROID_ADB_SERVER_PORT -ErrorAction SilentlyContinue
+$script:AdbServerPortProbe = { @{} }                                   # nothing listening -> base port
+Eq 'adb-port: all free -> base 15037'                 '15037' (Resolve-AdbServerPort)
+$script:AdbServerPortProbe = { @{ 15037 = 'other' } }                  # a stranger holds 15037
+Eq 'adb-port: 15037 taken by a stranger -> 15038'     '15038' (Resolve-AdbServerPort)
+$script:AdbServerPortProbe = { @{ 15037 = 'other'; 15038 = 'other' } } # two strangers -> skip both
+Eq 'adb-port: skips two taken ports -> 15039'         '15039' (Resolve-AdbServerPort)
+$script:AdbServerPortProbe = { @{ 15037 = 'ours' } }                   # our own HD-Adb server -> reuse it
+Eq 'adb-port: our own HD-Adb server -> reuse 15037'   '15037' (Resolve-AdbServerPort)
+$script:AdbServerPortProbe = { @{ 15037 = 'other'; 15039 = 'ours' } }  # first FREE wins over a later reusable
+Eq 'adb-port: stranger on 15037 -> first free 15038'  '15038' (Resolve-AdbServerPort)
+$env:ANDROID_ADB_SERVER_PORT = '5037'                                  # explicit override is honoured
+Eq 'adb-port: explicit env override is respected'     '5037'  (Resolve-AdbServerPort)
+$script:AdbServerPortProbe = $null
+Remove-Item Env:\ANDROID_ADB_SERVER_PORT -ErrorAction SilentlyContinue
+if ($savedPort) { $env:ANDROID_ADB_SERVER_PORT = $savedPort }
+
 Write-Host "`n=== DataRoot resolution (orchestrator Get-DataRoot, custom/registry) ===" -ForegroundColor Cyan
 Eq 'DataRoot: ...\Engine is normalized to base'      'X:\Custom\BS'   (Get-DataRoot ([pscustomobject]@{ DataDir = 'X:\Custom\BS\Engine'; UserDefinedDir = $null }))
 Eq 'DataRoot: plain data dir kept as-is'             'X:\Custom\Data' (Get-DataRoot ([pscustomobject]@{ DataDir = 'X:\Custom\Data'; UserDefinedDir = $null }))

--- a/todolist.md
+++ b/todolist.md
@@ -1,6 +1,14 @@
 # Todo List
 
 ## Done
+- [x] **adb robustness: immune to adb-version conflicts + live-bound port detection** — `Boot-And-Wait`
+      was timing out ("did not become adb-reachable") on hosts that also have a *different-version* system
+      `adb` (Android SDK v1.0.41 vs BlueStacks HD-Adb v1.0.36) fighting over the default server port 5037
+      (*"server version doesn't match; killing…"*). Fixed by pinning HD-Adb to a private
+      `ANDROID_ADB_SERVER_PORT=15037` + only ever using `HD-Adb.exe`, and by merging the **live-bound**
+      listening port into `Get-AdbPortCandidates` (rescues a stale `status.adb_port`). Proven live: 30/30
+      isolated getprop OK with a v41 server on 5037 (0/12 on the shared port), 20/20 stable port detection,
+      full Boot-And-Wait end-to-end PASS. +3 resolve tests (25), re-embedded, all suites green (28+25).
 - [x] **bundled a custom Kitsune v31 build so the in-app DenyList works with ReZygisk/NeoZygisk** — the deny
       module now stores entries in the `denylist` table (not `hidelist`), built from
       `Jordan231111/KitsuneMagisk@25fa2159f`. Re-embedded (`reembed-apk.ps1`, SHA `fac319d2…`, round-trip OK),

--- a/todolist.md
+++ b/todolist.md
@@ -5,10 +5,12 @@
       was timing out ("did not become adb-reachable") on hosts that also have a *different-version* system
       `adb` (Android SDK v1.0.41 vs BlueStacks HD-Adb v1.0.36) fighting over the default server port 5037
       (*"server version doesn't match; killing…"*). Fixed by pinning HD-Adb to a private
-      `ANDROID_ADB_SERVER_PORT=15037` + only ever using `HD-Adb.exe`, and by merging the **live-bound**
+      a private `ANDROID_ADB_SERVER_PORT` (auto-picked FREE from 15037-15057, so it never collides with
+      something already on 15037) + only ever using `HD-Adb.exe`, and by merging the **live-bound**
       listening port into `Get-AdbPortCandidates` (rescues a stale `status.adb_port`). Proven live: 30/30
       isolated getprop OK with a v41 server on 5037 (0/12 on the shared port), 20/20 stable port detection,
-      full Boot-And-Wait end-to-end PASS. +3 resolve tests (25), re-embedded, all suites green (28+25).
+      free-port probe steps 15037->15038 around a stranger, full Boot-And-Wait end-to-end PASS. +9 resolve
+      tests (31), re-embedded, all suites green (28+31).
 - [x] **bundled a custom Kitsune v31 build so the in-app DenyList works with ReZygisk/NeoZygisk** — the deny
       module now stores entries in the `denylist` table (not `hidelist`), built from
       `Jordan231111/KitsuneMagisk@25fa2159f`. Re-embedded (`reembed-apk.ps1`, SHA `fac319d2…`, round-trip OK),

--- a/tools/bsr_engine.ps1
+++ b/tools/bsr_engine.ps1
@@ -883,6 +883,30 @@ function AdbRaw([string[]]$a) {
 function AdbS([string[]]$a) { return AdbRaw (@('-s', $Script:Serial) + $a) }
 function AdbShell([string]$cmd) { return AdbS @('shell', $cmd) }
 
+# Map listening ports in our private band to 'ours' (a reusable HD-Adb.exe server) or 'other' (a non-adb
+# app, or a foreign-version adb we must not fight). Absent = free. (Mirrors tools\bsr_magisk.ps1.)
+function Get-AdbServerPortState {
+    $state = @{}
+    try {
+        foreach ($c in (Get-NetTCPConnection -State Listen -ErrorAction Stop)) {
+            $p = [int]$c.LocalPort; if ($p -lt 15037 -or $p -gt 15057) { continue }
+            $path = $null; try { $path = (Get-Process -Id $c.OwningProcess -ErrorAction SilentlyContinue).Path } catch { }
+            $state[$p] = if ($path -and ((Split-Path -Leaf $path) -ieq 'HD-Adb.exe')) { 'ours' } else { 'other' }
+        }
+    } catch {
+        try { foreach ($ln in (netstat -ano -p tcp 2>$null)) { if ($ln -match 'LISTENING' -and $ln -match ':(\d{4,5})\b') { $p = [int]$Matches[1]; if ($p -ge 15037 -and $p -le 15057 -and -not $state.ContainsKey($p)) { $state[$p] = 'other' } } } } catch { }
+    }
+    return $state
+}
+# Pick a private adb-server port that is FREE (or already hosts our own HD-Adb server), so we never
+# collide with something already using 15037 before this run. Explicit env override wins.
+function Resolve-AdbServerPort {
+    if ($env:ANDROID_ADB_SERVER_PORT) { return $env:ANDROID_ADB_SERVER_PORT }
+    $state = Get-AdbServerPortState
+    foreach ($p in 15037..15057) { $s = $state[$p]; if (-not $s -or $s -eq 'ours') { return "$p" } }
+    return '15037'
+}
+
 # Connect to the instance's adb endpoint and wait until Android finishes booting.
 function Connect-WaitBoot([int]$timeoutSec) {
     $port = if ($AdbPort) { $AdbPort } else { '5555' }
@@ -890,7 +914,7 @@ function Connect-WaitBoot([int]$timeoutSec) {
     # Isolate HD-Adb on its own server port so a different-version system adb (e.g. Android SDK
     # platform-tools) on the default 5037 can't kill our server mid-run (the version-mismatch churn
     # that makes getprop/shell calls fail and a booted instance look "not adb-reachable").
-    if (-not $env:ANDROID_ADB_SERVER_PORT) { $env:ANDROID_ADB_SERVER_PORT = '15037' }
+    if (-not $env:ANDROID_ADB_SERVER_PORT) { $env:ANDROID_ADB_SERVER_PORT = (Resolve-AdbServerPort) }
     AdbRaw @('start-server') | Out-Null
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $connected = $false

--- a/tools/bsr_engine.ps1
+++ b/tools/bsr_engine.ps1
@@ -887,6 +887,10 @@ function AdbShell([string]$cmd) { return AdbS @('shell', $cmd) }
 function Connect-WaitBoot([int]$timeoutSec) {
     $port = if ($AdbPort) { $AdbPort } else { '5555' }
     $Script:Serial = "127.0.0.1:$port"
+    # Isolate HD-Adb on its own server port so a different-version system adb (e.g. Android SDK
+    # platform-tools) on the default 5037 can't kill our server mid-run (the version-mismatch churn
+    # that makes getprop/shell calls fail and a booted instance look "not adb-reachable").
+    if (-not $env:ANDROID_ADB_SERVER_PORT) { $env:ANDROID_ADB_SERVER_PORT = '15037' }
     AdbRaw @('start-server') | Out-Null
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $connected = $false

--- a/tools/bsr_magisk.ps1
+++ b/tools/bsr_magisk.ps1
@@ -389,15 +389,42 @@ function Set-ConfKey($key,$val){
 # ---- adb helpers ----
 function Adb([string[]]$a){ (& $Adb @a 2>&1 | Out-String) }
 
-# Force HD-Adb onto its OWN private server port so a DIFFERENT-version system adb on the default 5037
-# (e.g. Android SDK platform-tools, which is v1.0.41 vs BlueStacks' HD-Adb v1.0.36) can't kill our
-# server mid-run. That version clash ("server version doesn't match; killing...") silently breaks
-# getprop/shell calls -- which is exactly how a fully-booted instance still trips Boot-And-Wait's
-# "did not become adb-reachable" throw. A private port ALSO gives us a clean transport table (no stale
-# 'offline' devices left by other adb sessions). HD-Adb v1.0.36 honours ANDROID_ADB_SERVER_PORT.
+# --- adb server isolation + private-port selection (version-conflict immunity) ---
 $Script:AdbServerInit = $false
+# Test seam: tests set this to a scriptblock returning @{ <port> = 'ours'|'other' } (absent key = free).
+$Script:AdbServerPortProbe = $null
+# Map listening ports in our private band to 'ours' (an HD-Adb.exe server we can safely reuse) or
+# 'other' (anything else -- a non-adb app, OR a foreign-version adb we must NOT fight). Absent = free.
+function Get-AdbServerPortState{
+    $state=@{}
+    try{
+        foreach($c in (Get-NetTCPConnection -State Listen -ErrorAction Stop)){
+            $p=[int]$c.LocalPort; if($p -lt 15037 -or $p -gt 15057){ continue }
+            $path=$null; try{ $path=(Get-Process -Id $c.OwningProcess -ErrorAction SilentlyContinue).Path }catch{}
+            $state[$p] = if($path -and ((Split-Path -Leaf $path) -ieq 'HD-Adb.exe')){ 'ours' } else { 'other' }
+        }
+    }catch{   # no NetTCPIP module: fall back to netstat (owner unknown -> treat any listener as 'other')
+        try{ foreach($ln in (netstat -ano -p tcp 2>$null)){ if($ln -match 'LISTENING' -and $ln -match ':(\d{4,5})\b'){ $p=[int]$Matches[1]; if($p -ge 15037 -and $p -le 15057 -and -not $state.ContainsKey($p)){ $state[$p]='other' } } } }catch{}
+    }
+    return $state
+}
+# Pick a private adb-server port that is FREE (or already hosts our own HD-Adb server). THIS is what
+# handles "something is already using 15037 before my session": a non-adb app or a foreign-version adb
+# on a candidate port is skipped, so we never collide with it and never kill it. An explicitly-set
+# ANDROID_ADB_SERVER_PORT always wins (escape hatch). 15037..15057 gives 21 ports of headroom.
+function Resolve-AdbServerPort{
+    if($env:ANDROID_ADB_SERVER_PORT){ return $env:ANDROID_ADB_SERVER_PORT }
+    $state = if($Script:AdbServerPortProbe){ & $Script:AdbServerPortProbe } else { Get-AdbServerPortState }
+    foreach($p in 15037..15057){ $s=$state[$p]; if(-not $s -or $s -eq 'ours'){ return "$p" } }
+    return '15037'   # band fully occupied (extreme) -- proceed; a later adb error would surface it clearly
+}
+# Force HD-Adb onto our resolved private server port so a DIFFERENT-version system adb on the default
+# 5037 (Android SDK platform-tools v1.0.41 vs HD-Adb v1.0.36) can't kill our server mid-run. The clash
+# ("server version doesn't match; killing...") silently breaks getprop/shell calls -- exactly how a
+# fully-booted instance still trips Boot-And-Wait's "did not become adb-reachable" throw. A private
+# port also gives us a clean transport table (no stale 'offline' devices). HD-Adb honours the env var.
 function Initialize-AdbServer{
-    if(-not $env:ANDROID_ADB_SERVER_PORT){ $env:ANDROID_ADB_SERVER_PORT = '15037' }
+    if(-not $env:ANDROID_ADB_SERVER_PORT){ $env:ANDROID_ADB_SERVER_PORT = (Resolve-AdbServerPort) }
     if(-not (Test-Path -LiteralPath $Adb)){ return }
     if(-not $Script:AdbServerInit){ & $Adb @('kill-server') *>$null; $Script:AdbServerInit=$true }  # clean slate on OUR port
     & $Adb @('start-server') *>$null   # idempotent; also revives the server after Kill-BlueStacks nukes HD-Adb
@@ -742,13 +769,20 @@ function Do-Undo {
 # Only dispatch when run normally (-File / &). When DOT-SOURCED (. bsr_magisk.ps1) -- e.g. by the test
 # suite to unit-test the resolver functions -- skip the pipeline so nothing boots or writes.
 if ($MyInvocation.InvocationName -ne '.') {
-    switch($Action){
-        'Prep'     { Do-Prep }
-        'Data'     { Do-Data }
-        'Clean'    { Do-Clean }
-        'Finalize' { Do-Finalize }
-        'Verify'   { Do-Verify }
-        'Auto'     { Do-Prep; Do-Data; Do-Clean; Do-Finalize; Do-Verify }
-        'Undo'     { Do-Undo }
+    try {
+        switch($Action){
+            'Prep'     { Do-Prep }
+            'Data'     { Do-Data }
+            'Clean'    { Do-Clean }
+            'Finalize' { Do-Finalize }
+            'Verify'   { Do-Verify }
+            'Auto'     { Do-Prep; Do-Data; Do-Clean; Do-Finalize; Do-Verify }
+            'Undo'     { Do-Undo }
+        }
+    } finally {
+        # Free our private adb-server port on the way out. adb normally leaves its server running
+        # forever; we only ever started one if Initialize-AdbServer ran (an online action), so tidy it
+        # up so nothing of ours lingers on the port after the tool exits. (runs even if an action threw)
+        if ($Script:AdbServerInit -and (Test-Path -LiteralPath $Adb)) { & $Adb @('kill-server') *>$null }
     }
 }

--- a/tools/bsr_magisk.ps1
+++ b/tools/bsr_magisk.ps1
@@ -90,7 +90,24 @@ if (-not $Debugfs) {
 }
 if (-not $Conf)    { $Conf = Join-Path $DataRoot 'bluestacks.conf' }
 if (-not $Vhd -and $Instance) { $Vhd = Join-Path $DataRoot "Engine\$Instance\Root.vhd" }
-$Adb    = Join-Path $Install 'HD-Adb.exe'
+# Resolve BlueStacks' OWN adb (HD-Adb.exe). We deliberately do NOT fall back to a system adb.exe:
+# mixing a system adb (e.g. Android SDK platform-tools v1.0.41) with BlueStacks' HD-Adb (v1.0.36)
+# triggers the "adb server version doesn't match this client; killing..." war -- the two kill each
+# other's server, getprop/shell calls fail intermittently, and a fully-booted instance can still
+# fail Boot-And-Wait with "did not become adb-reachable". So we pin HD-Adb.exe specifically.
+function Resolve-HdAdb {
+    $c = New-Object System.Collections.Generic.List[string]
+    if($Install){ [void]$c.Add((Join-Path $Install 'HD-Adb.exe')) }
+    if($reg -and $reg.InstallDir){ [void]$c.Add((Join-Path ($reg.InstallDir.TrimEnd('\','/')) 'HD-Adb.exe')) }
+    foreach($p in @((Join-Path $env:ProgramFiles 'BlueStacks_nxt\HD-Adb.exe'),
+                    (Join-Path ${env:ProgramFiles(x86)} 'BlueStacks_nxt\HD-Adb.exe'),
+                    (Join-Path $env:ProgramFiles 'BlueStacks_msi5\HD-Adb.exe'),
+                    (Join-Path ${env:ProgramFiles(x86)} 'BlueStacks_msi5\HD-Adb.exe'))){ [void]$c.Add($p) }
+    foreach($p in $c){ if($p -and (Test-Path -LiteralPath $p)){ return (Resolve-Path -LiteralPath $p).Path } }
+    $g = Get-Command 'HD-Adb.exe' -ErrorAction SilentlyContinue; if($g){ return $g.Source }
+    return (Join-Path $Install 'HD-Adb.exe')   # most-likely path even if absent (a later check reports it)
+}
+$Adb    = Resolve-HdAdb
 $Player = Join-Path $Install 'HD-Player.exe'
 $BsrSu  = if($BsrSuPath){$BsrSuPath}else{ Join-Path $Here 'su_src\bsr_su' }   # the setuid bootstrap su (4968 B)
 
@@ -371,10 +388,54 @@ function Set-ConfKey($key,$val){
 
 # ---- adb helpers ----
 function Adb([string[]]$a){ (& $Adb @a 2>&1 | Out-String) }
-# Candidate adb ports for THIS instance, in priority order, from BlueStacks' OWN conf -- NEVER hardcoded
-# to 5555. status.adb_port is the runtime port BlueStacks writes on boot; adb_port is the Multi-Instance
-# Manager's assigned port (clones get 5585/5595/...); 5555 is only a last-resort fallback. Boot-And-Wait
-# tries each AND verifies identity, so a stale status value or a foreign emulator on a port can't mislead.
+
+# Force HD-Adb onto its OWN private server port so a DIFFERENT-version system adb on the default 5037
+# (e.g. Android SDK platform-tools, which is v1.0.41 vs BlueStacks' HD-Adb v1.0.36) can't kill our
+# server mid-run. That version clash ("server version doesn't match; killing...") silently breaks
+# getprop/shell calls -- which is exactly how a fully-booted instance still trips Boot-And-Wait's
+# "did not become adb-reachable" throw. A private port ALSO gives us a clean transport table (no stale
+# 'offline' devices left by other adb sessions). HD-Adb v1.0.36 honours ANDROID_ADB_SERVER_PORT.
+$Script:AdbServerInit = $false
+function Initialize-AdbServer{
+    if(-not $env:ANDROID_ADB_SERVER_PORT){ $env:ANDROID_ADB_SERVER_PORT = '15037' }
+    if(-not (Test-Path -LiteralPath $Adb)){ return }
+    if(-not $Script:AdbServerInit){ & $Adb @('kill-server') *>$null; $Script:AdbServerInit=$true }  # clean slate on OUR port
+    & $Adb @('start-server') *>$null   # idempotent; also revives the server after Kill-BlueStacks nukes HD-Adb
+}
+
+# Test seam: the unit tests dot-source this file and set $Script:LiveAdbPortProbe to a scriptblock so
+# the live scan is deterministic (it otherwise depends on what is really listening on the host).
+$Script:LiveAdbPortProbe = $null
+# Ports actually LISTENING in the BlueStacks adb band right now. This catches what the conf can get
+# wrong: a clone can rebind a port that differs from BOTH status.adb_port and adb_port (verified in the
+# wild -- when an instance's usual port is held by a leftover socket, BlueStacks records one port but
+# binds another). We do NOT filter by owning process (the forwarder may be a privileged VM proc we
+# can't name without elevation); every candidate is still verified by getprop + Is-BlueStacks in
+# Boot-And-Wait, so a non-instance port here is harmless. Band 5550-5900 spans BlueStacks' clone ports
+# (base 5555, clones +10 per instance => _9 = 5645, etc.).
+function Get-LiveAdbPorts{
+    if($Script:LiveAdbPortProbe){ return @(& $Script:LiveAdbPortProbe) }
+    $out=New-Object System.Collections.Generic.List[string]
+    try{
+        Get-NetTCPConnection -State Listen -ErrorAction Stop |
+            Where-Object { $_.LocalPort -ge 5550 -and $_.LocalPort -le 5900 } |
+            ForEach-Object { [void]$out.Add([string]$_.LocalPort) }
+    }catch{
+        try{   # fallback for hosts without the NetTCPIP module
+            foreach($ln in (netstat -ano -p tcp 2>$null)){
+                if($ln -match 'LISTENING' -and $ln -match ':(\d{4,5})\b'){ $p=[int]$Matches[1]; if($p -ge 5550 -and $p -le 5900){ [void]$out.Add([string]$p) } }
+            }
+        }catch{}
+    }
+    return @($out | Sort-Object -Unique)
+}
+
+# Candidate adb ports for THIS instance, in priority order. status.adb_port is the runtime port
+# BlueStacks writes on boot; adb_port is the Multi-Instance Manager's assigned port (clones get
+# 5585/5595/...). Those (from BlueStacks' OWN conf) come FIRST -- authoritative when fresh. Then the
+# actually-bound listening ports, which rescue us when the conf is stale. 5555 is the last resort.
+# NEVER hardcoded to a single value; Boot-And-Wait tries each AND verifies identity, so a stale conf
+# value or a foreign emulator on a port can't mislead.
 function Get-AdbPortCandidates{
     $cands=New-Object System.Collections.Generic.List[string]
     if($Conf -and (Test-Path $Conf)){
@@ -386,6 +447,7 @@ function Get-AdbPortCandidates{
             }
         }catch{}
     }
+    foreach($lp in @(Get-LiveAdbPorts)){ [void]$cands.Add($lp) }   # live bound ports rescue a stale conf
     [void]$cands.Add('5555')
     $seen=@{}; $out=@(); foreach($c in $cands){ if(-not $seen.ContainsKey($c)){ $seen[$c]=$true; $out+=$c } }
     ,$out
@@ -423,6 +485,7 @@ function AdbTry([string[]]$a,[int]$tries=4){
 }
 function AdbSu([string]$serial,[string]$cmd){ AdbShellRetry $serial "/system/xbin/su -c '$cmd'" }
 function Boot-And-Wait([int]$timeoutSec=300){
+    Initialize-AdbServer   # pin HD-Adb to its private server port BEFORE any connect (version-conflict immunity)
     Say "[*] launching instance $Instance ..." Cyan
     Start-Process -FilePath $Player -ArgumentList @('--instance',$Instance) | Out-Null
     # Find the adb endpoint from BlueStacks' OWN per-instance conf ports (re-read each pass: BlueStacks


### PR DESCRIPTION
## The report

A user hit `instance '<name>' did not boot / become adb-reachable within 300 s` even though the instance **was fully booted** (Home visible, Magisk installed). The instance was never the problem.

## Root cause (reproduced on this machine)

The host had a **system `adb` of a different version** — Android SDK platform-tools **v1.0.41** at `…\Android\Sdk\platform-tools\adb.exe` — alongside BlueStacks' bundled **HD-Adb v1.0.36**. When both touch the **default adb server port 5037**, they kill each other:

```
adb server version (41) doesn't match this client (36); killing...
error: device '127.0.0.1:5645' not found
```

So every `getprop sys.boot_completed` the tool issued failed, and `Boot-And-Wait` timed out at the throw.

## The fix (host-side adb plumbing only)

- **Version-conflict immunity** — pin HD-Adb to its **own private server port** `ANDROID_ADB_SERVER_PORT=15037`, and only ever use `HD-Adb.exe` (`Resolve-HdAdb`, never a system `adb.exe`). A foreign-version adb on 5037 can no longer touch our server. *(HD-Adb v1.0.36 honours the env var — verified.)*
- **Port detection hardened** — `Get-AdbPortCandidates` now also consults the **actually-bound listening port** (`Get-NetTCPConnection`, band 5550-5900), merged **after** the `bluestacks.conf` `status.adb_port`/`adb_port` values (which stay authoritative). Rescues the boot wait when the conf is stale.
- Mirror of the isolation in the engine's `Connect-WaitBoot`.
- **No** change to the rooting pipeline, the embedded Magisk APK, or any on-disk format.

## Validation (live, on `Tiramisu64_9`)

| Test | Result |
|---|---|
| Port detection, 20 runs | `cands=[5645,5555]` identical all 20×, **0 missed** the real port |
| Isolated (15037) + v41 server on 5037, 30× getprop | **OK=30, FAIL=0** |
| Control (shared 5037, v36+v41), 12× getprop | **OK=0, FAIL=12** — reproduces the exact reporter error |
| Full `Boot-And-Wait` with v41 squatting 5037 | **PASS** — booted, `boot_completed=1`, `Is-BlueStacks=True` |

Also note: conf `status.adb_port=5646` was **stale** while the instance was really on **5645** — the live scan found 5645 independently (the second value of the port-detection hardening).

## Tests
- `tests/Run-Resolve-Tests.ps1`: deterministic probe seam + 3 new conf+live merge/dedup cases → **25/25**
- `tests/Run-Tests.ps1` → **28/28**
- `tests/Check-Embedded-Sync.ps1` → engine + orchestrator + APK in sync (re-embedded `blueStackRoot.cmd`)